### PR TITLE
Small cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-        
     - name: Installing golangci-lint
-      run: wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.23.8
+      run: wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.31.0
     - run: ./hack/build.sh
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # go-ktls
 
-A small library that manages a TLS secret in Kubernetes.
+A small library that manages a TLS secret in Kubernetes and a command-line tool.
+

--- a/cmd/ktls/main.go
+++ b/cmd/ktls/main.go
@@ -136,6 +136,7 @@ func patchCABundleCommand() *cobra.Command {
 	var (
 		resource     string
 		resourceName string
+		path         string
 	)
 	c := &cobra.Command{
 		Use:   "patch-ca-bundle",
@@ -160,16 +161,17 @@ func patchCABundleCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var path string
-			switch resource {
-			case "mutatingwebhookconfigurations":
-				fallthrough
-			case "validatingwebhookconfigurations":
-				path = "/webhooks/0/clientConfig/caBundle"
-			case "apiservices":
-				path = "/spec/caBundle"
-			default:
-				return fmt.Errorf("unknown resource %s", resource)
+			if path == "" {
+				switch gvr.Resource {
+				case "mutatingwebhookconfigurations":
+					fallthrough
+				case "validatingwebhookconfigurations":
+					path = "/webhooks/0/clientConfig/caBundle"
+				case "apiservices":
+					path = "/spec/caBundle"
+				default:
+					return fmt.Errorf("no defaulth path for resource %s, use --path", resource)
+				}
 			}
 			ckp, err := secret.GetCertificateKeyPair()
 			if err != nil {
@@ -190,6 +192,7 @@ func patchCABundleCommand() *cobra.Command {
 	flags := c.Flags()
 	flags.StringVar(&resource, "resource", "", "The resource to patch")
 	flags.StringVar(&resourceName, "resource-name", "", "The name of the resource to patch")
+	flags.StringVar(&path, "patch-path", "", "The JSON patch path to patch")
 	addFlags(flags)
 	return c
 }

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM golang:1.14-buster as build
 
-RUN wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.31.0
-
 WORKDIR /go/src/app
 
 # run this in a separate step to cache modules between builds


### PR DESCRIPTION
* Don't install golangci-lint in image build as it's not used

* Allow patch path to be given on command line

* Use golangci-lint v1.31.0 in build

Signed-off-by: Sam Shen <slshen@users.noreply.github.com>